### PR TITLE
Add basic parser tests

### DIFF
--- a/src/syntax/errors.rs
+++ b/src/syntax/errors.rs
@@ -1,6 +1,6 @@
 use super::{Field, Object, Output};
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Clone, Copy)]
 #[repr(u32)]
 pub enum RepackErrorKind {
     CannotWriteFile,

--- a/src/syntax/mod.rs
+++ b/src/syntax/mod.rs
@@ -12,6 +12,9 @@ mod snippet;
 mod tokens;
 mod types;
 
+#[cfg(test)]
+mod tests;
+
 pub use errors::*;
 pub use field::*;
 pub use field_function::*;

--- a/src/syntax/tests.rs
+++ b/src/syntax/tests.rs
@@ -1,0 +1,40 @@
+use super::*;
+
+#[test]
+fn parse_sample_file() {
+    use std::path::PathBuf;
+
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("test")
+        .join("test.repack");
+    let contents = FileContents::new(path.to_str().unwrap());
+    let result = ParseResult::from_contents(contents).expect("parse failed");
+
+    assert!(result.objects.iter().any(|o| o.name == "User"));
+    assert!(result.objects.iter().any(|o| o.name == "Todo"));
+
+    let user = result.objects.iter().find(|o| o.name == "User").unwrap();
+    let field_names: Vec<_> = user.fields.iter().map(|f| f.name.as_str()).collect();
+    assert!(field_names.contains(&"id"));
+    assert!(field_names.contains(&"org_id"));
+
+    let langs: Vec<_> = result.languages.iter().map(|l| l.profile.as_str()).collect();
+    assert!(langs.contains(&"postgres"));
+    assert!(langs.contains(&"rust"));
+}
+
+#[test]
+fn parse_invalid_emits_errors() {
+    use std::path::PathBuf;
+
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("test")
+        .join("invalid.repack");
+    let contents = FileContents::new(path.to_str().unwrap());
+    let errs = ParseResult::from_contents(contents).expect_err("expected errors");
+
+    let kinds: Vec<_> = errs.iter().map(|e| e.error).collect();
+    assert!(kinds.contains(&RepackErrorKind::UnknownLanguage));
+    assert!(kinds.contains(&RepackErrorKind::NoTableName));
+    assert!(kinds.contains(&RepackErrorKind::NoFields));
+}

--- a/test/invalid.repack
+++ b/test/invalid.repack
@@ -1,0 +1,4 @@
+output badlang @./out;
+
+record Foo {
+}


### PR DESCRIPTION
## Summary
- create unit tests to parse definition files
- validate that invalid definitions emit errors
- update tests to build paths using `PathBuf`

## Testing
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_6840bb113514833297a1c9e44c7e32c2